### PR TITLE
PartialMessage型のサポートを追加

### DIFF
--- a/src/handlers/commands/util/snipe.ts
+++ b/src/handlers/commands/util/snipe.ts
@@ -137,7 +137,7 @@ export default new Command({
                             ).toISOString(),
                             color: Colors.Blue,
                             image: {
-                                url: `https://25dsnipe.com/${sniped_message.newMessage.author.id}`,
+                                url: `https://25dsnipe.com/${sniped_message.newMessage.author?.id}`,
                             },
                         },
                     ],

--- a/src/interfaces/RegisterMessageOptions.ts
+++ b/src/interfaces/RegisterMessageOptions.ts
@@ -1,17 +1,15 @@
-import { Message, OmitPartialGroupDMChannel, PartialMessage } from 'discord.js';
-
-type Msg = OmitPartialGroupDMChannel<Message<boolean> | PartialMessage>;
+import { Message, PartialMessage } from 'discord.js';
 
 interface RegisterDeleteMessageOptions {
     type: 'delete';
-    message: Msg;
+    message: Message | PartialMessage;
     newMessage?: never;
 }
 
 interface RegisterEditMessageOptions {
     type: 'edit';
-    message: Msg;
-    newMessage: Msg;
+    message: Message | PartialMessage;
+    newMessage: Message | PartialMessage;
 }
 
 export type RegisterMessageOptions =

--- a/src/libraries/Classes/Miku.ts
+++ b/src/libraries/Classes/Miku.ts
@@ -8,6 +8,7 @@ import {
     EmbedFooterData,
     InteractionContextType,
     Message,
+    PartialMessage,
 } from 'discord.js';
 import { Logger } from '@/libraries/Classes/Utils/Logger';
 import { promisify } from 'util';
@@ -65,10 +66,13 @@ export class Miku extends Client {
     public globPromise = promisify(glob);
 
     /* Snipeのキャッシュ */
-    public snipes = new Collection<string, Message>();
+    public snipes = new Collection<string, Message | PartialMessage>();
     public edit_snipes = new Collection<
         string,
-        { oldMessage: Message; newMessage: Message }
+        {
+            oldMessage: Message | PartialMessage;
+            newMessage: Message | PartialMessage;
+        }
     >();
 
     public logger = new Logger();

--- a/src/libraries/Classes/Modules/Snipe.ts
+++ b/src/libraries/Classes/Modules/Snipe.ts
@@ -1,13 +1,16 @@
-import { Channel, Collection, Message } from 'discord.js';
+import { Channel, Collection, Message, PartialMessage } from 'discord.js';
 import { client } from '@/index';
 import { RegisterMessageOptions } from '@/interfaces/RegisterMessageOptions';
 
 export class Snipe {
     private channel: Channel;
-    private snipes: Collection<string, Message>;
+    private snipes: Collection<string, Message | PartialMessage>;
     private editSnipes: Collection<
         string,
-        { oldMessage: Message; newMessage: Message }
+        {
+            oldMessage: Message | PartialMessage;
+            newMessage: Message | PartialMessage;
+        }
     >;
 
     constructor(channel: Channel) {


### PR DESCRIPTION
Messageに加えてPartialMessage型もサポートするように変更しました。これにより、Discord.js上で部分的なメッセージオブジェクトの処理が可能になります。関連する型定義とクラスメンバーを適切に更新しました。